### PR TITLE
Update grid layout for larger screens in App.css

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -66,8 +66,8 @@
   
   @media screen and (min-width: 1440px) {
     .Pictures {
-      grid-template-columns: repeat(3, 1fr);
-      margin-left: 200px;
+      grid-template-columns: repeat(4, 1fr);
+      margin-left: auto;
       margin-right: auto;
       margin-top: 190px;
       max-width: 1200px;


### PR DESCRIPTION
This pull request includes a change to the `src/App.css` file to adjust the layout of the `.Pictures` class for screens with a minimum width of 1440px. 

* [`src/App.css`](diffhunk://#diff-60f5dcfc15327d5dd812d9df394c217efbedb4aa33dca782ed69d39dce811972L69-R70): Modified the `.Pictures` class to use a 4-column grid layout instead of 3 columns and adjusted the left margin to be automatic instead of a fixed 200px.

## Before

![image](https://github.com/user-attachments/assets/0220867a-860c-4639-a34c-c8700642d2d6)

## After

![image](https://github.com/user-attachments/assets/1a085939-0ed7-4180-9fca-3dd54b4153e4)
